### PR TITLE
Add daemonset.yaml file

### DIFF
--- a/daemonset.yaml
+++ b/daemonset.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: frr-daemonset
+  namespace: default
+  labels:
+    app: frr-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: frr-daemonset
+  template:
+    metadata: 
+      labels:
+        app: frr
+        name: frr-daemonset
+    spec:
+      hostNetwork: true
+      volumes:
+        - name: frr-config
+          configMap:
+            name: frr-config
+      containers:
+      - name: frr-daemonset
+        image: docker.io/frrouting/frr
+        volumeMounts:
+        - mountPath: "/etc/frr"
+          name: frr-config
+        securityContext:
+          capabilities:
+            add: ["NET_ADMIN","NET_RAW","SYS_ADMIN"]
+


### PR DESCRIPTION
This Daemonset deploys FRR containers, using a configmap named frr-config.
Moreover, it uses the hostNetwork property for making the pods IP
addresses the same as the nodes IP.
Also, NET_ADMIN, NET_RAW, SYS_ADMIN permissions are granted for
the FRR to work.